### PR TITLE
(maint) bump centos-8

### DIFF
--- a/centos-8/http/ks.cfg
+++ b/centos-8/http/ks.cfg
@@ -1,4 +1,3 @@
-cdrom
 lang en_US.UTF-8
 keyboard us
 network --onboot yes --device eth0 --bootproto dhcp
@@ -12,6 +11,8 @@ bootloader --location=mbr --driveorder=sda,sdb,sdc --append="crashkernel=auto bi
 text
 skipx
 zerombr
+
+url --url=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
 
 clearpart --all --initlabel
 autopart

--- a/centos-8/template-base-vars.json
+++ b/centos-8/template-base-vars.json
@@ -1,7 +1,7 @@
 {
   "os": "centos-8",
-  "iso_url": "http://ftp.osuosl.org/pub/centos/8/isos/x86_64/CentOS-8.2.2004-x86_64-minimal.iso",
-  "iso_checksum": "47ab14778c823acae2ee6d365d76a9aed3f95bb8d0add23a06536b58bb5293c0",
+  "iso_url": "http://ftp.osuosl.org/pub/centos/8/isos/x86_64/CentOS-8.3.2011-x86_64-boot.iso",
+  "iso_checksum": "2b801bc5801816d0cf27fc74552cf058951c42c7b72b1fe313429b1070c3876c",
   "iso_checksum_type": "sha256",
   "boot_command_start": "<tab><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><wait5>",
   "boot_command_options": " biosdevname=0 net.ifnames=0 quiet vga=791",


### PR DESCRIPTION
Bump centos-8 to 8.3 and switch to the boot ISO.  The minimal ISO doesn't
currently appear to be available for 8.3.

Force a network install since we're using the boot ISO.